### PR TITLE
fix: CLI 产物改用分支名 + 通配符自动定位，去除版本号参数

### DIFF
--- a/Jenkinsfile.android
+++ b/Jenkinsfile.android
@@ -35,9 +35,10 @@ combo:
 }
 
 def installComboCLI() {
-    def comboZip = "combo-cli_${CLI_VERSION}_darwin_arm64.zip"
-    copyArtifacts projectName: "SDK/Client/Combo/cli/${CLI_NAME}", filter: comboZip
-    unzip comboZip
+    def comboZipGlob = "combo-cli_*_darwin_arm64.zip"
+    copyArtifacts projectName: "SDK/Client/Combo/cli/${CLI_NAME}", selector: lastSuccessful(), filter: comboZipGlob
+    def files = findFiles glob: comboZipGlob
+    unzip files[0].name
 }
 
 def getTargetDistros() {
@@ -98,11 +99,7 @@ pipeline {
             trim: true)
         string(name: 'CLI_NAME',
             defaultValue: "main",
-            description: 'cli branch name（用于定位 SDK/Client/Combo/cli 下对应分支的 Jenkins 工程）',
-            trim: true)
-        string(name: 'CLI_VERSION',
-            defaultValue: "2.27.0-dev",
-            description: 'cli 版本号（用于定位构建产物文件名 combo-cli_<CLI_VERSION>_darwin_arm64.zip，取自 combo-cli 仓库 core/version/version.go 中的 CLIVersion）',
+            description: 'cli branch name（用于定位 SDK/Client/Combo/cli 下对应分支的 Jenkins 工程，并在该分支最近一次成功构建的产物中匹配 combo-cli_*_darwin_arm64.zip）',
             trim: true)
         choice(name: 'BUILD_TYPE', choices: ['release', 'debug'], description: '默认不需要关心')
         booleanParam(name: 'ENABLE_KEEP_RENDERING_ON_PAUSE',

--- a/Jenkinsfile.ios
+++ b/Jenkinsfile.ios
@@ -32,15 +32,6 @@ combo:
 """
 }
 
-// def downloadFrameworks() {
-//     def frameworkZip = "*.zip"
-//     copyArtifacts projectName: params.IOS_PROJECT_NAME, selector: lastSuccessful(), filter: frameworkZip, excludes: "*dsym*.zip"
-
-//     def files = findFiles glob: frameworkZip
-//     unzip zipFile: files[0].name, dir: env.COMBO_SDK_PATH, quiet: true
-//     sh "rm -f ${files[0].name}"
-// }
-
 def assembleXcodeProject() {
     sh '''
         rm -rf ~/Library/Developer/Xcode/DerivedData
@@ -65,10 +56,11 @@ def installComboCLI() {
         writeComboYaml(COMBOSDK_BUILD_KEY)
     }
 
-    def comboZip = "combo-cli_${CLI_VERSION}_darwin_arm64.zip"
-    copyArtifacts projectName: "SDK/Client/Combo/cli/${CLI_NAME}", filter: comboZip
-    unzip zipFile: comboZip, quiet: true
-    sh "rm -f ${comboZip}"
+    def comboZipGlob = "combo-cli_*_darwin_arm64.zip"
+    copyArtifacts projectName: "SDK/Client/Combo/cli/${CLI_NAME}", selector: lastSuccessful(), filter: comboZipGlob
+    def files = findFiles glob: comboZipGlob
+    unzip zipFile: files[0].name, quiet: true
+    sh "rm -f ${files[0].name}"
 }
 
 def getComboCredentialsId(String credentialSuffix) {
@@ -154,21 +146,13 @@ pipeline {
             quoteValue: false,
             saveJSONParameterToFile: false
         )
-        string(name: 'IOS_PROJECT_NAME',
-            defaultValue: 'SDK/Client/Combo/ios/main',
-            description: 'iOS 工程的 Jenkins Full project name',
-            trim: true)
         string(name: 'UNITY_SDK_PROJECT_NAME',
             defaultValue: "SDK/Client/Combo/unity/${env.BRANCH_NAME}",
             description: 'Unity SDK 工程的 Jenkins Full project name',
             trim: true)
         string(name: 'CLI_NAME',
             defaultValue: "main",
-            description: 'cli branch name（用于定位 SDK/Client/Combo/cli 下对应分支的 Jenkins 工程）',
-            trim: true)
-        string(name: 'CLI_VERSION',
-            defaultValue: "2.27.0-dev",
-            description: 'cli 版本号（用于定位构建产物文件名 combo-cli_<CLI_VERSION>_darwin_arm64.zip，取自 combo-cli 仓库 core/version/version.go 中的 CLIVersion）',
+            description: 'cli branch name（用于定位 SDK/Client/Combo/cli 下对应分支的 Jenkins 工程，并在该分支最近一次成功构建的产物中匹配 combo-cli_*_darwin_arm64.zip）',
             trim: true)
         choice(name: 'SKIP_EXPORT', choices: ['NO', 'AUTO', 'YES'], description: '是否跳过 Export Project stage ')
         choice(name: 'SCREEN_ORIENTATION', choices: ['Landscape', 'Portrait'], description: '设置 Demo 横屏幕方向: 横屏/竖屏')
@@ -179,7 +163,6 @@ pipeline {
     environment {
         UNITY_ROOT = getUnityRoot('2021.3.45f1')
         BUILD_DIR = "${env.WORKSPACE}/build"
-        COMBO_SDK_PATH = "${env.WORKSPACE}/ComboSDK"
         IOS_IPA = artifactName(name: "combo-demo", extension: "ipa")
         UNITY_SDK_PATH = "${env.WORKSPACE}/Packages"
         CAPABILITIES = params.CAPABILITIES.toString()
@@ -196,7 +179,6 @@ pipeline {
                         rm -rf *.ipa
                         rm -rf *.zip
                         rm -rf logs/*
-                        rm -rf ${env.COMBO_SDK_PATH}
                         rm -rf ${env.UNITY_SDK_PATH}/com.seayoo.sdk
                     """
                 }
@@ -235,8 +217,6 @@ pipeline {
                 script {
                     loadEnvironmentParams()
                     installComboCLI()
-                    // downloadFrameworks()
-                    // downloadComboSDKJson()
                 }
             }
         }

--- a/Jenkinsfile.windows
+++ b/Jenkinsfile.windows
@@ -74,9 +74,10 @@ combo:
 }
 
 def installComboCLI() {
-    def comboZip = "combo-cli_${CLI_VERSION}_windows_amd64.zip"
-    copyArtifacts projectName: "SDK/Client/Combo/cli/${CLI_NAME}", filter: comboZip
-    unzip comboZip
+    def comboZipGlob = "combo-cli_*_windows_amd64.zip"
+    copyArtifacts projectName: "SDK/Client/Combo/cli/${CLI_NAME}", selector: lastSuccessful(), filter: comboZipGlob
+    def files = findFiles glob: comboZipGlob
+    unzip files[0].name
 }
 
 pipeline {
@@ -119,11 +120,7 @@ pipeline {
             trim: true)
         string(name: 'CLI_NAME',
             defaultValue: "main",
-            description: 'cli branch name（用于定位 SDK/Client/Combo/cli 下对应分支的 Jenkins 工程）',
-            trim: true)
-        string(name: 'CLI_VERSION',
-            defaultValue: "2.27.0-dev",
-            description: 'cli 版本号（用于定位构建产物文件名 combo-cli_<CLI_VERSION>_windows_amd64.zip，取自 combo-cli 仓库 core/version/version.go 中的 CLIVersion）',
+            description: 'cli branch name（用于定位 SDK/Client/Combo/cli 下对应分支的 Jenkins 工程，并在该分支最近一次成功构建的产物中匹配 combo-cli_*_windows_amd64.zip）',
             trim: true)
         booleanParam(name: 'CLEAN_WS',
             defaultValue: false,


### PR DESCRIPTION
## Summary
- Jenkinsfile.android / Jenkinsfile.ios / Jenkinsfile.windows：installComboCLI() 不再用 CLI_VERSION 拼接精确文件名，改为用 CLI_NAME 定位到对应分支的 Jenkins 工程后，在其最近一次成功构建的产物中用通配符 combo-cli_*_<平台>.zip 自动匹配，去除了 CLI_VERSION 参数，触发构建时只需填分支名
- Jenkinsfile.ios：清理已废弃的 iOS Framework 下载逻辑（downloadFrameworks()、IOS_PROJECT_NAME、COMBO_SDK_PATH），该能力已迁移至 combo ios setup --xcode-autoconf，原下载逻辑早已被注释未再启用

## Test plan
- [ ] 分别触发 Jenkinsfile.android / Jenkinsfile.ios / Jenkinsfile.windows 构建，确认只填 CLI_NAME 能正确拉取到对应平台的 combo-cli 产物
- [ ] 确认 iOS 构建流程（combo ios setup --xcode-autoconf → xcodebuild）不受清理影响，IPA 正常产出

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSxXcsrk9g2M91nNxJuFDL